### PR TITLE
Update en-us.json

### DIFF
--- a/src/Assets/L10N/en-us.json
+++ b/src/Assets/L10N/en-us.json
@@ -157,7 +157,7 @@
     "ar": "Arabic",
     "ckb": "Central Kurdish",
     "en-US": "English (United States)",
-    "fr-CA": "French (Canada)",
+    "fr": "French",
     "ja-JP": "Japanese",
     "kmr": "Northern Kurdish"
   },


### PR DESCRIPTION
French will not be separated into “Canadian French” or “French French” since this language is universal in terms of how it is written.

(French file coming soon)